### PR TITLE
Removed data exclusions from ErrorPlugin

### DIFF
--- a/src/main/java/com/exceptionless/exceptionlessclient/plugins/preconfigured/ErrorPlugin.java
+++ b/src/main/java/com/exceptionless/exceptionlessclient/plugins/preconfigured/ErrorPlugin.java
@@ -8,7 +8,6 @@ import com.exceptionless.exceptionlessclient.models.enums.EventType;
 import com.exceptionless.exceptionlessclient.plugins.EventPluginIF;
 import lombok.Builder;
 
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -16,30 +15,8 @@ import java.util.Set;
 public class ErrorPlugin implements EventPluginIF {
   private static final Integer DEFAULT_PRIORITY = 30;
 
-  private final Set<String> dataExclusions;
-
   @Builder
-  public ErrorPlugin() {
-    this.dataExclusions =
-        new HashSet<>(
-            Arrays.asList(
-                "arguments",
-                "column",
-                "columnNumber",
-                "description",
-                "fileName",
-                "message",
-                "name",
-                "number",
-                "line",
-                "lineNumber",
-                "opera#sourceloc",
-                "sourceId",
-                "sourceURL",
-                "stack",
-                "stackArray",
-                "stacktrace"));
-  }
+  public ErrorPlugin() {}
 
   @Override
   public int getPriority() {
@@ -48,7 +25,7 @@ public class ErrorPlugin implements EventPluginIF {
 
   @Override
   public void run(
-          EventPluginContext eventPluginContext, ConfigurationManager configurationManager) {
+      EventPluginContext eventPluginContext, ConfigurationManager configurationManager) {
     Exception exception = eventPluginContext.getContext().getException();
     if (exception == null) {
       return;
@@ -63,7 +40,6 @@ public class ErrorPlugin implements EventPluginIF {
     event.addError(configurationManager.getErrorParser().parse(exception));
 
     Set<String> dataExclusions = new HashSet<>(configurationManager.getDataExclusions());
-    dataExclusions.addAll(this.dataExclusions);
     event.addData(Map.of(EventPropertyKey.EXTRA.value(), exception), dataExclusions);
   }
 }

--- a/src/test/java/com/exceptionless/exceptionlessclient/plugins/preconfigured/ErrorPluginTest.java
+++ b/src/test/java/com/exceptionless/exceptionlessclient/plugins/preconfigured/ErrorPluginTest.java
@@ -8,7 +8,6 @@ import com.exceptionless.exceptionlessclient.models.PluginContext;
 import com.exceptionless.exceptionlessclient.models.enums.EventPropertyKey;
 import com.exceptionless.exceptionlessclient.models.enums.EventType;
 import com.exceptionless.exceptionlessclient.models.services.error.StackFrame;
-import com.exceptionless.exceptionlessclient.plugins.preconfigured.ErrorPlugin;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,10 +27,11 @@ public class ErrorPluginTest {
 
   @Test
   public void itCanAddExceptionToEventCorrectly() {
+    Exception exc = new RuntimeException("test");
     EventPluginContext context =
         EventPluginContext.builder()
             .event(Event.builder().build())
-            .context(PluginContext.builder().exception(new RuntimeException("test")).build())
+            .context(PluginContext.builder().exception(exc).build())
             .build();
 
     plugin.run(context, configurationManager);
@@ -51,12 +51,6 @@ public class ErrorPluginTest {
     assertThat(data).isNotNull();
     assertThat(data).containsKey(EventPropertyKey.EXTRA.value());
 
-    Map<String, Object> extra = (Map<String, Object>) data.get(EventPropertyKey.EXTRA.value());
-    assertThat(extra).isNotNull();
-    assertThat(extra).doesNotContainKey("message");
-    assertThat(extra).doesNotContainKey("cause");
-    assertThat(extra).doesNotContainKey("stackTrace");
-    assertThat(extra).containsKey("suppressed");
-    assertThat(extra).containsKey("localizedMessage");
+    assertThat(data.get(EventPropertyKey.EXTRA.value())).isSameAs(exc);
   }
 }


### PR DESCRIPTION
Ref:

> Error plugin
> For the error plugin the exclusions was extra properties that are stored on the Exception object that we didn't want to include in an errors extended data that we capture. We'd want to update this for java or remove it.