### PR TITLE
Caching module info

### DIFF
--- a/src/main/java/com/exceptionless/exceptionlessclient/services/DefaultModuleCollector.java
+++ b/src/main/java/com/exceptionless/exceptionlessclient/services/DefaultModuleCollector.java
@@ -7,13 +7,18 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class DefaultModuleCollector implements ModuleCollectorIF {
+  private final List<Module> modules;
+
   @Builder
-  public DefaultModuleCollector() {}
+  public DefaultModuleCollector() {
+    this.modules =
+        ModuleLayer.boot().modules().stream()
+            .map(module -> Module.builder().name(module.getName()).build())
+            .collect(Collectors.toList());
+  }
 
   @Override
   public List<Module> getModules() {
-    return ModuleLayer.boot().modules().stream()
-        .map(module -> Module.builder().name(module.getName()).build())
-        .collect(Collectors.toList());
+    return modules;
   }
 }


### PR DESCRIPTION
Ref:

> Module info
> We should cache this as I'm guessing this is expensive to compute every time run is called.