### PR TITLE
Disabling failure on empty beans during serialization

### DIFF
--- a/src/main/java/com/exceptionless/exceptionlessclient/utils/Utils.java
+++ b/src/main/java/com/exceptionless/exceptionlessclient/utils/Utils.java
@@ -17,6 +17,7 @@ public final class Utils {
     JSON_MAPPER = new ObjectMapper();
     JSON_MAPPER.registerModule(new JavaTimeModule());
     JSON_MAPPER.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    JSON_MAPPER.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
   }
 
   private static final Logger LOG = LoggerFactory.getLogger(Utils.class);

--- a/src/test/java/com/exceptionless/exceptionlessclient/ExceptionlessClientTest.java
+++ b/src/test/java/com/exceptionless/exceptionlessclient/ExceptionlessClientTest.java
@@ -1,18 +1,18 @@
 package com.exceptionless.exceptionlessclient;
 
 import com.exceptionless.exceptionlessclient.configuration.ConfigurationManager;
-import com.exceptionless.exceptionlessclient.models.Event;
-import com.exceptionless.exceptionlessclient.models.UserDescription;
 import com.exceptionless.exceptionlessclient.enums.EventPropertyKey;
 import com.exceptionless.exceptionlessclient.enums.EventType;
-import com.exceptionless.exceptionlessclient.settings.SettingsResponse;
-import com.exceptionless.exceptionlessclient.submission.SubmissionResponse;
+import com.exceptionless.exceptionlessclient.models.Event;
+import com.exceptionless.exceptionlessclient.models.UserDescription;
 import com.exceptionless.exceptionlessclient.queue.DefaultEventQueue;
 import com.exceptionless.exceptionlessclient.settings.DefaultSettingsClient;
 import com.exceptionless.exceptionlessclient.settings.ServerSettings;
+import com.exceptionless.exceptionlessclient.settings.SettingsResponse;
 import com.exceptionless.exceptionlessclient.storage.InMemoryStorage;
 import com.exceptionless.exceptionlessclient.storage.InMemoryStorageProvider;
 import com.exceptionless.exceptionlessclient.submission.DefaultSubmissionClient;
+import com.exceptionless.exceptionlessclient.submission.SubmissionResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/com/exceptionless/exceptionlessclient/utils/UtilsTest.java
+++ b/src/test/java/com/exceptionless/exceptionlessclient/utils/UtilsTest.java
@@ -1,5 +1,6 @@
 package com.exceptionless.exceptionlessclient.utils;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
@@ -79,5 +80,12 @@ public class UtilsTest {
   public void itCanMatchAValueToAPattern() {
     assertThat(Utils.match("abc", "def")).isFalse();
     assertThat(Utils.match("ABC", "abc")).isTrue();
+  }
+
+  @Test
+  public void itCanSerializeEmptyBeans() throws JsonProcessingException {
+    class EmptyBean {}
+
+    assertThat(Utils.JSON_MAPPER.writeValueAsString(new EmptyBean())).isEqualTo("{}");
   }
 }


### PR DESCRIPTION
By default Jackson (Java's default serialization library) fail on empty beans. So while submitting additional data with events users might not know which beans are empty so disabling it.

Close #58 